### PR TITLE
Added Rust internal module example, Fixed markdown code space issue

### DIFF
--- a/ajay/README.md
+++ b/ajay/README.md
@@ -81,49 +81,59 @@ To compile statically-typed language such as C/C++ we need to install Emscripten
 The steps to install Emscripten are as such:
 
 - Clone the repository using command </br>
+
    ```
    git clone https://github.com/emscripten-core/emsdk.git
    ```
 - Navigate to the `emsdk` directory </br>
+
   ```
   cd emsdk
   ```
 - make sure clones repository is updated with remote one: </br>
+
   ```
   git pull
   ```
 - Install the latest version of Emscripten </br>
+
   ```
   ./emsdk install latest
   ```
 - Activate the latest version </br>
+
   ```
   ./emsdk activate latest
   ```
 - Set the various environmental variables </br>
+
   ```
   source ./emsdk_env.sh
   ```
-
 - Check Installation </br>
+
   ```
   emcc --version
   ```
-
 - To Compile C/C++ programs </br>
+
   ```
   emcc hello.c -s WASM=1 -o hello.html  
   ```
   </br>
+
   ```  
   em++ hello.cpp -s WASM=1 -o hello.html    
   ```
 
 - For only  wasm file </br>
+
   ```
   emcc hello.c -s STANDALONE_WASM
   ```
+
   </br>
+
   ```
   em++ hello.cpp -s STANDALONE_WASM
   ```
@@ -155,4 +165,5 @@ Start a server using node server
     A program to calculate total time taken to count 1M.
   - [Rust Examples](./nowBrowser/rustWasm)
     - [Simple Hello Program](./nowBrowser/rustWasm/hello)
+    - [Rust Module](./nowBrowser/rustWasm/rust_module)
     - [Markdown Parser](./nowBrowser/rust/rustWasm/markdown_parser)

--- a/ajay/callingCprogramsFunction/README.md
+++ b/ajay/callingCprogramsFunction/README.md
@@ -6,18 +6,18 @@ When we want to call a custom function we need specify as a Exported function wh
 When we call a `C function` let `_greetX()` then a pointer to that message/string is being returned, to read that `Memory location` it privide an inbuild function called `   ccall()   `.  
 
 ### Passing an arguments string/number using `ccall`
-When we call `_greetX` function it return a pointer to a Memory location, and when we pass a parameter to it, it simply ignored it. To pass string/number as a parameter we can use `  ccall  ` as such:
+When we call `_greetX` function it return a pointer to a Memory location, and when we pass a parameter to it, it simply ignored it. To pass string/number as a parameter we can use `  ccall  ` as such:</br>
+
 ```
 ccall('Function Name', 'Return Type', ['Parameter Type'], [Parameter])
 
 For argument of string type: ccall('greetX', 'string', ['string'], ['stringParameter'])
 For argument of number type: ccall('wCount', 'number', ['number'], [1])
-
 ```
 
 ### Wrapping a function using `cwrap`
 
-As we can see that whenever we need to call a function i.e. `greetX` with some parameter we need to specify return type, parameter type, etc, so to make it easier we can use function `cwrap` which will wrap it up, and we can use it for a normal function calling.
+As we can see that whenever we need to call a function i.e. `greetX` with some parameter we need to specify return type, parameter type, etc, so to make it easier we can use function `cwrap` which will wrap it up, and we can use it for a normal function calling.</br>
 
 ```
 const wGreet = cwrap('greetX', 'string', ['string']);
@@ -27,9 +27,11 @@ wGreet('String Parameter');
 
 Command to Export function is as such:
 ### Compilation
+
 ```
 emcc forLoop.c -s WASM=1 -s EXPORTED_FUNCTIONS='['_wCount', '_main', '_greetX']'  -o forLoop.js
 ```
+
 It will export wcount and main function specified in our c code and a `  wasm  ` file which will have all our logic and a `   js   ` file which is a glue code help to load wasm to browser, here we need to include only js file to our `   HTML  ` file.
 
 </br>
@@ -37,7 +39,8 @@ It will export wcount and main function specified in our c code and a `  wasm  `
 
 ### Serving files
 
-To start a inbuilt server provided by Emscripten itself used Command:
+To start a inbuilt server provided by Emscripten itself used Command:</br>
+
 ```
 emrun --no_browser --port 8080 index.html
 ```

--- a/ajay/helloAjay/README.md
+++ b/ajay/helloAjay/README.md
@@ -2,6 +2,7 @@
 
 - Write C/C++ program
 - Compile program usin command </br>
+
 ```
 emcc hello.c -s WASM=1 -o index.html
 ```
@@ -9,6 +10,7 @@ This will generate three files. A `HTML` file to show our content, `wasm` file w
 
 
 - Serve Emscripten HTML page</br>
+
 ```
 emrun --no_browser --port 8080 index.html
 ```

--- a/ajay/nowBrowser/README.md
+++ b/ajay/nowBrowser/README.md
@@ -39,15 +39,16 @@ Wasmer is a WebAssembly runtime having support for system interface `  WASI  `
 
 ### Installation
 To install `Wasmer runtime` run the following command
+
 ```
 curl https://get.wasmer.io -sSfL | sh
 ```
 
 ### Serving `WASM` file
+
 ```
 wasmer run test.wasm
 ```
-
 
 ### Examples
 
@@ -56,4 +57,5 @@ wasmer run test.wasm
   A program to calculate total time taken to count 1M.
 - [Rust Examples](./rustWasm)
   - [Simple Hello Program](./rustWasm/hello)
+  - [Rust Module](./rustWasm/rust_module)
   - [Markdown Parser](./rustWasm/markdown_parser)

--- a/ajay/nowBrowser/rustWasm/README.md
+++ b/ajay/nowBrowser/rustWasm/README.md
@@ -29,7 +29,6 @@
 
   ```
   cargo install cargo-wasi
-
   ```
 
 - ### wasmtime
@@ -39,17 +38,17 @@
 
   ```
   curl https://wasmtime.dev/install.sh -sSf | bash
-
   ```
 
 
  ### Command to create and run a Simple project [Hello](./hello).
 
  - Create a project name `hello`
- ```
- cargo new hello
 
  ```
+ cargo new hello
+ ```
+
  It will create a folder containing a subfolder ` src ` and a ` toml  ` file having project information such as project name, version, dependencies, etc. while  `  src  ` folder have a rust file `  main.rs ` having a function named ` main  ` with a greeting message `Hello, world!` from where execution get started.
 
  - Move inside `hello`
@@ -59,17 +58,18 @@
   ```
 
 - Compile and Run Project `hello`
+
   ```
   cargo wasi run
   ```
+
   This will compile and run the hello project inside of wasp time automatically.
   We can also run it using `wasmtime` like such:
 
   ```
   wasmtime target/wasm32-wasi/debug/hello.wasm
-
   ```
 
-
 ### Other projects
+- [Rust Module](./rust_module)
 - [Markdown Parser](./markdown_parser)

--- a/ajay/nowBrowser/rustWasm/markdown_parser/README.md
+++ b/ajay/nowBrowser/rustWasm/markdown_parser/README.md
@@ -8,58 +8,47 @@ A markdown parser, which parses any Markdown file, produces and log out HTML on 
 
 ## Used Commands
 
-- Project creation
+- Project creation</br>
+
   ```
   cargo new --bin markdown_parser
-
   ```
-- Wasm file creation or compilation
+
+- Wasm file creation or compilation</br>
+
   ```
   cargo build --target wasm32-wasi
-
   ```
 
-  - Parsing and logging out the Markdown or Execution
+  - Parsing and logging out the Markdown or Execution</br>
 
   ```
   wasmtime --dir . target/wasm32-wasi/debug/markdown_parser.wasm -- README.md
-
   ```
 
 ### Input
 This markdown file itself, when not having current headings `Input` ,  `Output` and its content.
 
-
 ### Output
+
 ```
 <h1>Markdown Parser</h1>
 <p><img src="./../../../img/markdwonParser.gif" alt="Rust To Wasm" /></p>
-<p>A markdown parser, which parse any Markdown file, produce and log out HTML on terminal. As shown in above illustration the steps required to perform the same are as such:</p>
+<p>A markdown parser, which parses any Markdown file, produces and log out HTML on terminal. As shown in above illustration the steps required to perform the same are as such:</p>
 <ul>
 <li>Rust code get compiled by <code>cargo-wasi</code> to produce a <code>.wasm</code> file</li>
-<li>WebAssembly runtime <code>wasmtime</code> execute the <code>.wasm</code> file with input <code>markdown</code> file which we and to parse, and log the <code>html</code> output on terminal. Here we need to pass our data directory so that it preload the file because WebAssembly run into a sandbox environment.</li>
+<li>WebAssembly runtime <code>wasmtime</code> executes the <code>.wasm</code> file with input <code>markdown</code> file which we want to parse, and log the <code>html</code> output on terminal. Here we need to pass our data directory so that it preloads the file because WebAssembly runs into a sandbox environment.</li>
 </ul>
 <h2>Used Commands</h2>
 <ul>
-<li>
-<p>Project creation</p>
-<pre><code>cargo new --bin markdown_parser
-
-</code></pre>
-</li>
-<li>
-<p>Wasm file creation or compilation</p>
-<pre><code>cargo build --target wasm32-wasi
-
-</code></pre>
+<li>Project creation</br></li>
+</ul>
+<p>  <code>  cargo new --bin markdown_parser  </code></p>
 <ul>
-<li>Parsing and logging out the Markdown or Execution</li>
+<li>Wasm file creation or compilation</br></li>
 </ul>
-<pre><code>wasmtime --dir . target/wasm32-wasi/debug/markdown_parser.wasm -- README.md
-
-</code></pre>
-</li>
-</ul>
-
+<p>  <code>  cargo build --target wasm32-wasi  </code></p>
+<p>  - Parsing and logging out the Markdown or Execution</br></p>
+<p>  <code>  wasmtime --dir . target/wasm32-wasi/debug/markdown_parser.wasm -- README.md  </code></p>
 
 ```

--- a/ajay/nowBrowser/rustWasm/rust_module/Cargo.toml
+++ b/ajay/nowBrowser/rustWasm/rust_module/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_module"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ajay/nowBrowser/rustWasm/rust_module/README.md
+++ b/ajay/nowBrowser/rustWasm/rust_module/README.md
@@ -1,0 +1,65 @@
+
+# Module
+A logical group of code is called a Module. Multiple modules are compiled into a unit called crate where crate is a compilation unit in Rust.
+Modulea in Rust are private by default.
+
+### Declaration Syntax
+
+```
+mod private_module{
+
+    fn private_module_private_function(){
+        println!("private_module_private_function get called\n");
+    }
+    pub fn private_module_public_function(){
+        private_module_private_function();
+        println!("private_module_public_function get called\n");
+    }
+}
+
+
+pub mod public_module{
+
+    fn public_module_private_function(){
+        println!("public_module_private_function get called\n");
+    }
+    pub fn public_module_public_function(){
+        public_module_private_function();
+        println!("public_module_public_function get called\n");
+    }
+}
+```
+### Syntax for accessing Module's functions
+In Rust a Module can be private or public, similarily functions inside those modules also can be private and publice as shown in Declaration, while private functions can only be accessed by a public function which belong to same module say parent of both public and private module must be same. accessing Syntax are as such:
+
+- Method I of accessing functions
+```
+println!("Calling public Mudules functions");
+public_module_public_function();
+println!("Calling Private Modules Functions");
+private_module_public_function();
+```
+- Method II of accessing functions
+```
+println!("Calling public Mudules functions");
+public_module::public_module_public_function();
+println!("Calling Private Modules Functions");
+private_module::private_module_public_function();
+```
+## Commands to be perform
+- ### Project creation
+```
+cargo new --bin rust_module
+```
+- ### Nevigate inside Project
+```
+cd rust_module
+```
+- ### Project building/compilation
+```
+cargo wasi build
+```
+- ### Project execution
+```
+wasmtime target/wasm32-wasi/debug/rust_module.wasm
+```

--- a/ajay/nowBrowser/rustWasm/rust_module/src/main.rs
+++ b/ajay/nowBrowser/rustWasm/rust_module/src/main.rs
@@ -1,0 +1,43 @@
+
+pub mod public_module{
+
+    fn public_module_private_function(){
+        println!("public_module_private_function get called");
+    }
+    pub fn public_module_public_function(){
+        public_module_private_function();
+        println!("public_module_public_function get called\n");
+    }
+}
+
+mod private_module{
+
+    fn private_module_private_function(){
+        println!("private_module_private_function get called");
+    }
+    pub fn private_module_public_function(){
+        private_module_private_function();
+        println!("private_module_public_function get called\n");
+    }
+}
+
+
+use public_module::public_module_public_function;
+use private_module::private_module_public_function;
+
+
+fn main(){
+    
+    println!("--------------Method I of accessing functions------------");
+    println!("Calling public Mudules functions");
+    public_module_public_function();
+    println!("Calling Private Modules Functions");
+    private_module_public_function();
+
+    println!("\n--------------Method II of accessing functions------------");
+    println!("Calling public Mudules functions");
+    public_module::public_module_public_function();
+    println!("Calling Private Modules Functions");
+    private_module::private_module_public_function();
+
+}


### PR DESCRIPTION
- Added Rust module example and explained its public and private type along with their function declaration and accessibility.
-  Fixed markdown code space issue
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
